### PR TITLE
make run_ci_checks.sh fail fast (set -e)

### DIFF
--- a/run_ci_checks.sh
+++ b/run_ci_checks.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 ./run_autoformat.sh
 mypy .
 pytest . --pylint -m pylint --pylint-rcfile=.pylintrc


### PR DESCRIPTION
Mirrors the same fix applied in the prpl-mono monorepo. Without `set -e`, a failure in autoformat / mypy / pylint doesn't stop the script and the final `pytest tests/` output can mask the earlier failure.